### PR TITLE
Date in suggested citation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,6 @@ title: What are Digital Humanities?
 slogan: 'something'
 
 # The description is used on homepage and in the footer to quickly describe your website. Use a maximum of 150 characters for SEO-purposes.
-description: "The DHLG introduces digital humanities (DH) to the interested newcomer, featuring introductory project videos; lists of educational resources; and materials on how to engage in the DH community. Visitors will learn about DH, whether it's a route they want to pursue, and if so, how to take the first steps. Read more about the site, including its authors and how to contribute, <a href='/dhlg/about/'>here</a>."
 
 # The credits show up in the includes/_footer.html – It would be nice of you to leave a link to Phlow or Feeling Responsive as a thank you :)
 credits: '<p>A <a href="http://jekyllrb.com/" target="_blank">Jekyll</a> site designed by <a href="http://www.agilehumanities.ca">Agile Humanities</a> based on <a href="http://phlow.github.io/feeling-responsive/">Feeling Responsive</a>.</p>'

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -14,7 +14,7 @@
 
           <div class="large-3 small-8 columns">
             <h5>The DH Literacy Guidebook</h5>
-              {{ site.description | markdownify }}
+            <p>The DHLG introduces digital humanities to newcomers. Read more about the DHLG, its authors, and how to contribute <a href='/dhlg/about/'>here</a>. Cite the DHLG as: Weingart, Scott B., Susan Grunewald, Matthew Lincoln et al. (eds.). <i>The Digital Humanities Literacy Guidebook</i>. Carnegie Mellon University, 2019. https://cmu-lib.github.io/dhlg/. Accessed {{ site.time | date: '%B %d, %Y' }}.</p>
           </div><!-- /.large-6.columns -->
 
           <div class="large-3 medium-4 small-12 columns">


### PR DESCRIPTION
This PR adds a formatted date to the suggested citation in the footer.

Liquid markup can only be specified directly within a layout/include file; it can't be passed as a string from a data file like _config.yml. Therefore I've moved the `description` content directly into `_footer.html`, which should be OK since that is the only place it is used.

Closes #126